### PR TITLE
Add MathNet MKL provider

### DIFF
--- a/SharpFFTW.sln
+++ b/SharpFFTW.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28917.181
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpFFTW.Tests", "SharpFFTW.Tests\SharpFFTW.Tests.csproj", "{DA20704B-23A7-41A4-B4E2-174A0FED5F3D}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -33,7 +33,7 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DA20704B-23A7-41A4-B4E2-174A0FED5F3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DA20704B-23A7-41A4-B4E2-174A0FED5F3D}.Debug|x64.ActiveCfg = Debug|x64
-		{DA20704B-23A7-41A4-B4E2-174A0FED5F3D}.Release|Any CPU.ActiveCfg = Release|x86
+		{DA20704B-23A7-41A4-B4E2-174A0FED5F3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA20704B-23A7-41A4-B4E2-174A0FED5F3D}.Release|x64.ActiveCfg = Release|x64
 		{BEA875B8-E28A-49C5-8E7E-6512DA65F7E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BEA875B8-E28A-49C5-8E7E-6512DA65F7E1}.Debug|Any CPU.Build.0 = Debug|Any CPU

--- a/fftbench/fftbench.Common/Benchmark/TestMathNet.cs
+++ b/fftbench/fftbench.Common/Benchmark/TestMathNet.cs
@@ -1,12 +1,36 @@
 ﻿
 namespace fftbench.Benchmark
 {
+    using MathNet.Numerics;
     using MathNet.Numerics.IntegralTransforms;
 
     public class TestMathNet : BaseTest
     {
+        public bool UseMKL { get; set; }
+
+        private bool ProviderConfigured { get; set; }
+
+        private void ConfigureProvider()
+        {
+            if (!ProviderConfigured)
+            {
+                if (UseMKL)
+                {
+                    Control.UseNativeMKL();
+                }
+                else
+                {
+                    Control.UseManaged();
+                }
+
+                ProviderConfigured = true;
+            }
+        }
+
         public override void FFT(bool forward)
         {
+            ConfigureProvider();
+
             data.CopyTo(copy, 0);
 
             if (forward)
@@ -21,6 +45,8 @@ namespace fftbench.Benchmark
 
         public override double[] Spectrum(double[] input, bool scale)
         {
+            ConfigureProvider();
+
             var data = ToComplex(input);
 
             Fourier.Forward(data, FourierOptions.Default);
@@ -36,7 +62,7 @@ namespace fftbench.Benchmark
 
         public override string ToString()
         {
-            return "Math.NET";
+            return UseMKL ? "Math.NET+MKL" : "Math.NET";
         }
     }
 }

--- a/fftbench/fftbench.Common/Util.cs
+++ b/fftbench/fftbench.Common/Util.cs
@@ -13,6 +13,7 @@ namespace fftbench
             tests.Add(new TestAccord() { Enabled = true });
             tests.Add(new TestAForge() { Enabled = true });
             tests.Add(new TestMathNet() { Enabled = true });
+            tests.Add(new TestMathNet() { Enabled = true, UseMKL = true });
             tests.Add(new TestExocortex() { Enabled = true });
             tests.Add(new TestLomont() { Enabled = true });
             tests.Add(new TestNAudio() { Enabled = true });

--- a/fftbench/fftbench.Common/fftbench.Common.csproj
+++ b/fftbench/fftbench.Common/fftbench.Common.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Accord" Version="3.8.0" />
     <PackageReference Include="Accord.Math" Version="3.8.0" />
-    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    <PackageReference Include="MathNet.Numerics.Providers.MKL" Version="5.0.0" />
     <PackageReference Include="NAudio.Core" Version="2.1.0" />
     <PackageReference Include="NWaves" Version="0.9.6" />
   </ItemGroup>


### PR DESCRIPTION
Using the MathNet Intel MKL provider pushes MathNet up into 3rd place.

![image](https://user-images.githubusercontent.com/271656/183249504-c4f1ee05-cbe2-42a5-bbd4-8c951fb7edf1.png)
