### PR TITLE
Added test for Cavern's FFT

### DIFF
--- a/fftbench/fftbench.Common/Benchmark/TestCavern.cs
+++ b/fftbench/fftbench.Common/Benchmark/TestCavern.cs
@@ -1,0 +1,48 @@
+﻿
+namespace fftbench.Benchmark {
+    using Cavern.Utilities;
+
+    public class TestCavern : ITest {
+        public string Name => ToString();
+
+        public int Size => data.Length;
+
+        public bool Enabled { get; set; }
+
+        Complex[] data;
+
+        FFTCache cache;
+
+        public void Initialize(double[] data) {
+            this.data = new Complex[data.Length];
+            cache = new FFTCache(data.Length);
+            for (int i = 0; i < data.Length; i++) {
+                this.data[i].Real = (float)data[i];
+            }
+        }
+
+        public void FFT(bool forward) {
+            Complex[] workingSet = (Complex[])data.Clone();
+            Measurements.InPlaceFFT(workingSet, cache);
+        }
+
+        public double[] Spectrum(double[] input, bool scale) {
+            Complex[] workingSet = (Complex[])data.Clone();
+            Measurements.InPlaceFFT(workingSet, cache);
+
+            float[] spectrumSource = Measurements.GetSpectrum(workingSet);
+            double[] spectrum = new double[spectrumSource.Length];
+            Helper.CopyToDouble(spectrumSource, spectrum);
+
+            Measurements.InPlaceIFFT(workingSet, cache);
+            float[] ifftResult = Measurements.GetRealPart(workingSet);
+            Helper.CopyToDouble(ifftResult, input);
+
+            return spectrum;
+        }
+
+        public override string ToString() {
+            return "Cavern";
+        }
+    }
+}

--- a/fftbench/fftbench.Common/Util.cs
+++ b/fftbench/fftbench.Common/Util.cs
@@ -12,9 +12,10 @@ namespace fftbench
 
             tests.Add(new TestAccord() { Enabled = true });
             tests.Add(new TestAForge() { Enabled = true });
-            tests.Add(new TestMathNet() { Enabled = true });
+            tests.Add(new TestCavern() { Enabled = true });
             tests.Add(new TestExocortex() { Enabled = true });
             tests.Add(new TestLomont() { Enabled = true });
+            tests.Add(new TestMathNet() { Enabled = true });
             tests.Add(new TestNAudio() { Enabled = true });
             tests.Add(new TestNWaves() { Enabled = true });
             tests.Add(new TestExocortexReal() { Enabled = true });

--- a/fftbench/fftbench.Common/fftbench.Common.csproj
+++ b/fftbench/fftbench.Common/fftbench.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Copyright>Copyright © Christian Woltering 2016-2022</Copyright>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Accord" Version="3.8.0" />
     <PackageReference Include="Accord.Math" Version="3.8.0" />
+    <PackageReference Include="Cavern" Version="2.0.2" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="NAudio.Core" Version="2.2.1" />
     <PackageReference Include="NWaves" Version="0.9.6" />


### PR DESCRIPTION
Test implemented for Cavern's fully .NET FFT which rivals real FFTs at large sizes:

```
FFT size: 2^14 (16384)
  Repeat: 80

[11/11] Done

Exocortex (real):  1.0  [min:  149.54, max:  174.49, mean:  152.50, stddev:    3.69]
          Cavern:  1.4  [min:  204.24, max:  249.82, mean:  213.16, stddev:   10.16]
   NWaves (real):  1.5  [min:  220.79, max:  272.86, mean:  226.15, stddev:    7.82]
   Lomont (real):  1.8  [min:  273.96, max:  292.92, mean:  279.43, stddev:    3.88]
          Accord:  3.0  [min:  401.09, max:  693.31, mean:  462.60, stddev:   73.43]
          NWaves:  3.1  [min:  465.31, max:  518.50, mean:  473.22, stddev:    8.66]
          NAudio:  3.8  [min:  560.12, max:  614.02, mean:  573.28, stddev:    8.90]
       Exocortex:  4.9  [min:  737.58, max:  759.13, mean:  747.29, stddev:    4.24]
          Lomont:  5.0  [min:  751.17, max:  772.21, mean:  760.71, stddev:    4.65]
          AForge:  5.7  [min:  833.21, max: 1024.35, mean:  869.97, stddev:   31.89]
        Math.NET:  7.1  [min: 1024.33, max: 1198.71, mean: 1084.55, stddev:   28.94]

Timing in microseconds.
```